### PR TITLE
Fix KEEP_ALIVE_SEC to be 60 seconds

### DIFF
--- a/Adafruit_IO/mqtt_client.py
+++ b/Adafruit_IO/mqtt_client.py
@@ -24,7 +24,7 @@ import paho.mqtt.client as mqtt
 
 
 # How long to wait before sending a keep alive (paho-mqtt configuration).
-KEEP_ALIVE_SEC = 3600  # One minute
+KEEP_ALIVE_SEC = 60  # One minute
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fix KEEP_ALIVE_SEC to be 60 seconds instead of the current value of 3600 which is in fact an hour.
This fixes #25 which is an issue because the broker disconnects after 300 seconds with no ping.
